### PR TITLE
Avoid buffer overrun in b64url_decode() when the output size is not d…

### DIFF
--- a/src/cjwt.c
+++ b/src/cjwt.c
@@ -240,7 +240,10 @@ static int cjwt_verify_rsa( cjwt_t *jwt, const char *p_enc, const char *p_sigb64
     //decode p_sigb64
     sz_sigb64 = strlen( ( char * )p_sigb64 );
     sig_desize = b64url_get_decoded_buffer_size( sz_sigb64 );
-    decoded_sig = malloc( sig_desize + 1 );
+    //Because b64url_decode() always writes in blocks of 3 bytes for every 4 
+    //characters even when the last 2 bytes are not used, we need up to 2 
+    //extra bytes of output buffer to avoid a buffer overrun 
+    decoded_sig = malloc( sig_desize + 2 );
 
     if( !decoded_sig ) {
         cjwt_error( "memory allocation failed\n" );
@@ -250,7 +253,7 @@ static int cjwt_verify_rsa( cjwt_t *jwt, const char *p_enc, const char *p_sigb64
         return ENOMEM;
     }
 
-    memset( decoded_sig, 0, sig_desize + 1 );
+    memset( decoded_sig, 0, sig_desize + 2 );
     sig_desize = b64url_decode( ( uint8_t * )p_sigb64, sz_sigb64, decoded_sig );
     cjwt_info( "----------------- signature ----------------- \n" );
     cjwt_info( "Bytes = %d\n", ( int )sig_desize );


### PR DESCRIPTION
Consider the case where 256 bytes are encoded into base64 (for example, in our case it's for SHA256)
The resulting signature in jwt is 342 bytes long and represents 256 encoded bytes
When we call b64url_get_decoded_buffer_size() it correctly tells us that the decoded size will be 256 bytes
What it does not tell us is that when we call b64url_decode() from the trower-base64 library, the function internally calls decodeblock() with a pointer to a 3 byte block that it will write to.
This function ALWAYS writes to all 3 of those bytes, even if we only had 1 or 2 bytes in the original string.
Thus, in the worst case we need up to 2 extra bytes of working space.  We already allocated 1 extra byte and later set it to the null character, after the decode is done, though I am not sure why.
But, if we just allocote 2 extra bytes instead of 1, that will handle the worst case, and once the decode is finished, this overhead is not needed any more, and the next byte after the data ends can safely be set to null as we are already doing.
This seems simplest to just always have 2 extra bytes in the output buffer; we could do it conditionally, depending on whether the output size is evenly divisible by 3, but it doesn't seem worth it to save 1 byte of temporary buffer that will just get freed at the end of this function anyway, so I suggest just change the overhead to 2 bytes instead of 1 as it is now.
Before this change we were getting a crash and after this change the crash is gone.