### PR TITLE
Update trower-base64 so it does not overwrite memory boundaries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if (NOT BUILD_YOCTO)
 ExternalProject_Add(trower-base64
     PREFIX ${PREFIX_DIR}/trower-base64
     GIT_REPOSITORY https://github.com/Comcast/trower-base64.git
-    GIT_TAG "fbb9440ae2bc1118866baefcea7ff814f16613dd"
+    GIT_TAG "v1.1.2"
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF)
 add_library(libtrower-base64 STATIC SHARED IMPORTED)
 add_dependencies(libtrower-base64 trower-base64)


### PR DESCRIPTION
This should fix the issue expressed by #23 .  The root problem was due to using an out of date version of trower-base64.

I don't see unit tests with memory coverage on, so will add that in a later PR.