### PR TITLE
Add memchecking

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,11 +16,15 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-error=missing-field-initializers
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W  -g -fprofile-arcs -ftest-coverage -O0")
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -O0")
 
+if(NOT DISABLE_VALGRIND)
+set (MEMORY_CHECK valgrind --leak-check=full --show-reachable=yes --error-exitcode=1 -v)
+endif ()
+
 find_package (Threads)
 
 link_directories ( ${LIBRARY_DIR} )
 
-add_test(NAME cjwt_test COMMAND cjwt_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/.. )
+add_test(NAME cjwt_test COMMAND ${MEMORY_CHECK} cjwt_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/.. )
 add_executable(cjwt_test cjwt_test.c ../src/cjwt.c)
 
 target_link_libraries (cjwt_test -lssl -lcrypto -lpthread -ltrower-base64

--- a/tests/cjwt_test.c
+++ b/tests/cjwt_test.c
@@ -213,6 +213,7 @@ START_TEST( test_cjwt_decode )
         fail_cnt += 1;
     }
 
+    cjwt_destroy( &jwt );
     ck_assert_int_eq( expected, ( result == 0 ) );
     return;
 }


### PR DESCRIPTION
While this breaks the build, I am concerned that we're running with valgrind off by default.  There are many leaks due to the `libcheck` code used for unit testing.  I was not able to find a way to fix this. @bill1600 can you fix this or convert to CUnit (which doesn't have this problem)?