### PR TITLE
Improve base64 handling & replace trower-base64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ project(cjwt VERSION 1.0.3)
 include(BitwiseVersion)
 include(CTest)
 include(FindcJSON)
-include(FindTrowerBase64)
 include(LicenseLinterTarget)
 include(Coverage)
 
@@ -24,8 +23,7 @@ add_library(cjwt SHARED "")
 # Find or acquire software dependencies
 ################################################################################
 
-find_cjson(        PATH ${CJSON_PATH}  VERSION "1.0.0" GIT_TAG "")
-find_trower_base64(PATH ${TROWER_PATH}                 GIT_TAG "")
+find_cjson(PATH ${CJSON_PATH}  VERSION "1.0.0" GIT_TAG "")
 
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIRS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 target_sources(cjwt
     PRIVATE
         cjwt.c
+        b64.c
 )
 
 configure_file(cjwtver.h.in

--- a/src/b64.c
+++ b/src/b64.c
@@ -101,10 +101,13 @@ uint8_t* b64_url_decode( const char *in, size_t in_len, size_t *out_len )
 
     /* The +1 is a hack for now to give a character for a trailing '\0'
      * in the event that lengths are not honored. */
-    out = malloc( sizeof(uint8_t) * decoded_len + 1 );
+    out = malloc( decoded_len + 1 );
     if( !out ) {
         return NULL;
     }
+
+    /* The other part of the hack. */
+    out[decoded_len] = '\0';
 
     for( size_t i = 0, j = 0; i < in_len; i++ ) {
         int8_t val;
@@ -123,9 +126,6 @@ uint8_t* b64_url_decode( const char *in, size_t in_len, size_t *out_len )
             bit_count -= 8;
         }
     }
-
-    /* The other part of the hack. */
-    out[decoded_len] = '\0';
 
     if( out_len ) {
         *out_len = decoded_len;

--- a/src/b64.c
+++ b/src/b64.c
@@ -1,0 +1,134 @@
+/* SPDX-FileCopyrightText: 2021 Comcast Cable Communications Management, LLC */
+/* SPDX-FileCopyrightText: 2021 Weston Schmidt */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "b64.h"
+
+/*----------------------------------------------------------------------------*/
+/*                                   Macros                                   */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                               Data Structures                              */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                            File Scoped Variables                           */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                             Function Prototypes                            */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                             External Functions                             */
+/*----------------------------------------------------------------------------*/
+uint8_t* b64_url_decode( const char *in, size_t in_len, size_t *out_len )
+{
+    // -1 = invalid
+    // -2 = padding
+    static const int8_t map[256] = {
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0x00-0x0f */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0x10-0x1f */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,62,-1,-1,    /* 0x20-0x2f */
+        52,53,54,55, 56,57,58,59, 60,61,-1,-1, -1,-2,-1,-1,    /* 0x30-0x3f */
+        -1, 0, 1, 2,  3, 4, 5, 6,  7, 8, 9,10, 11,12,13,14,    /* 0x40-0x4f */
+        15,16,17,18, 19,20,21,22, 23,24,25,-1, -1,-1,-1,63,    /* 0x50-0x5f */
+        -1,26,27,28, 29,30,31,32, 33,34,35,36, 37,38,39,40,    /* 0x60-0x6f */
+        41,42,43,44, 45,46,47,48, 49,50,51,-1, -1,-1,-1,-1,    /* 0x70-0x7f */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0x80-0x8f */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0x90-0x9f */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0xa0-0xaf */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0xb0-0xbf */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0xc0-0xcf */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0xd0-0xdf */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0xe0-0xef */
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,    /* 0xf0-0xff */
+    };
+    uint32_t bits = 0;
+    int bit_count = 0;
+    size_t padding = 0;
+    size_t decoded_len = 0;
+    size_t remainder;
+    uint8_t *out = NULL;
+
+    if( !in || (in_len < 2) ) {
+        return NULL;
+    }
+
+    if( '=' == in[in_len - 1] ) {
+        padding++;
+        if( '=' == in[in_len - 2] ) {
+            padding++;
+        }
+    }
+
+    in_len -= padding;
+
+    /* This order of operations prevents overflow for really large numbers */
+    decoded_len = (in_len / 4) * 3;
+    remainder = 0x3 & in_len;
+
+    /* Remainder mapping:
+     *  Remainder | Extra bytes represented
+     *  ----------+------------------------
+     *          0 | 0
+     *          1 | invalid, exit with size 0
+     *          2 | 1
+     *          3 | 2
+     */
+
+    if( 1 == remainder ) {
+        return NULL;
+    } else if( 0 < remainder ) {
+        remainder--;
+    }
+
+    decoded_len += remainder;
+
+    /* The +1 is a hack for now to give a character for a trailing '\0'
+     * in the event that lengths are not honored. */
+    out = malloc( sizeof(uint8_t) * decoded_len + 1 );
+    if( !out ) {
+        return NULL;
+    }
+
+    for( size_t i = 0, j = 0; i < in_len; i++ ) {
+        int8_t val;
+
+        val = map[(uint8_t) in[i]];
+        if( val < 0 ) {
+            free( out );
+            return NULL;
+        }
+        bits = (bits << 6) | val;
+        bit_count += 6;
+
+        if( 8 <= bit_count ) {
+            out[j] = (uint8_t) (0x0ff & (bits >> (bit_count - 8)));
+            j++;
+            bit_count -= 8;
+        }
+    }
+
+    /* The other part of the hack. */
+    out[decoded_len] = '\0';
+
+    if( out_len ) {
+        *out_len = decoded_len;
+    }
+
+    return out;
+}
+
+/*----------------------------------------------------------------------------*/
+/*                             Internal functions                             */
+/*----------------------------------------------------------------------------*/
+/* none */

--- a/src/b64.c
+++ b/src/b64.c
@@ -68,6 +68,12 @@ uint8_t* b64_url_decode( const char *in, size_t in_len, size_t *out_len )
         if( '=' == in[in_len - 2] ) {
             padding++;
         }
+
+        /* If there is padding then it should only pad to ensure the string
+         * has a multiple of 4.  Anything else is an error. */
+        if( 0 != (0x03 & in_len) ) {
+            return NULL;
+        }
     }
 
     in_len -= padding;

--- a/src/b64.h
+++ b/src/b64.h
@@ -1,0 +1,28 @@
+/* SPDX-FileCopyrightText: 2021 Comcast Cable Communications Management, LLC */
+/* SPDX-FileCopyrightText: 2021 Weston Schmidt */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __B64_H__
+#define __B64_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ *  Takes the url base64 encoded buffer specified and converts it to the bytes
+ *  it represents and returns the bytes in a newly allocated buffer.  The new
+ *  size is returned via the out_len parameter if it is specified.
+ *
+ *  @note The resulting buffer is 1 byte longer & that byte contains a '\0' to
+ *        accomidate code that does not honor lengths.
+ *
+ *  @param in       the url base64 encoded buffer to decode
+ *  @param in_len   the number of bytes to process
+ *  @param out_len  the number of valid bytes returned in the buffer if not NULL
+ *
+ *  @return the buffer with the data or NULL if there is an error
+ */
+uint8_t* b64_url_decode( const char *in, size_t in_len, size_t *out_len );
+
+#endif
+

--- a/src/cjwt.c
+++ b/src/cjwt.c
@@ -7,7 +7,6 @@
 #include <errno.h>
 #include <stdio.h>
 
-#include <trower-base64/base64.h>
 #include <cjson/cJSON.h>
 
 #include <openssl/hmac.h>
@@ -18,6 +17,7 @@
 #include <openssl/bio.h>
 
 #include "cjwt.h"
+#include "b64.h"
 
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
@@ -61,8 +61,6 @@
 /*                             External Functions                             */
 /*----------------------------------------------------------------------------*/
 extern char *strdup(const char *s);
-extern size_t b64url_get_decoded_buffer_size( const size_t encoded_size );
-extern size_t b64url_decode( const uint8_t *input, const size_t input_size, uint8_t *output );
 
 
 /*----------------------------------------------------------------------------*/
@@ -155,7 +153,6 @@ static int cjwt_sign( cjwt_t *cjwt, unsigned char **out, const char *in, int *ou
         case alg_hs512:
             return cjwt_sign_sha_hmac( cjwt, out, EVP_sha512(), in, out_len );
         default :
-            return  -1;
     }//switch
 
     return -1;
@@ -195,7 +192,7 @@ rsa_end:
 
 static int cjwt_verify_rsa( cjwt_t *jwt, const char *p_enc, const char *p_sigb64 )
 {
-    int ret = EINVAL, sz_sigb64 = 0;
+    int ret = EINVAL;
     RSA *rsa = NULL;
     size_t enc_len = 0, sig_desize = 0;
     uint8_t *decoded_sig = NULL;
@@ -214,23 +211,8 @@ static int cjwt_verify_rsa( cjwt_t *jwt, const char *p_enc, const char *p_sigb64
     }
 
     //decode p_sigb64
-    sz_sigb64 = strlen( ( char * )p_sigb64 );
-    sig_desize = b64url_get_decoded_buffer_size( sz_sigb64 );
-    //Because b64url_decode() always writes in blocks of 3 bytes for every 4 
-    //characters even when the last 2 bytes are not used, we need up to 2 
-    //extra bytes of output buffer to avoid a buffer overrun 
-    decoded_sig = malloc( sig_desize + 2 );
+    decoded_sig = b64_url_decode( p_sigb64, strlen(p_sigb64), &sig_desize );
 
-    if( !decoded_sig ) {
-        cjwt_error( "memory allocation failed\n" );
-        //free rsa
-        RSA_free( rsa );
-        cjwt_rsa_error();
-        return ENOMEM;
-    }
-
-    memset( decoded_sig, 0, sig_desize + 2 );
-    sig_desize = b64url_decode( ( uint8_t * )p_sigb64, sz_sigb64, decoded_sig );
     cjwt_info( "----------------- signature ----------------- \n" );
     cjwt_info( "Bytes = %d\n", ( int )sig_desize );
     cjwt_info( "--------------------------------------------- \n" );
@@ -240,7 +222,6 @@ static int cjwt_verify_rsa( cjwt_t *jwt, const char *p_enc, const char *p_sigb64
         goto end;
     }
 
-    decoded_sig[sig_desize] = '\0';
     //verify rsa
     enc_len = strlen( p_enc );
 
@@ -286,6 +267,8 @@ static int cjwt_verify_signature( cjwt_t *p_jwt, char *p_in, const char *p_sign 
     int ret = 0;
     int sz_signed = 0;
     unsigned char* signed_out = NULL;
+    size_t sz_decoded = 0;
+    uint8_t *signed_dec;
 
     if( !p_jwt || !p_in || !p_sign ) {
         ret = EINVAL;
@@ -306,44 +289,31 @@ static int cjwt_verify_signature( cjwt_t *p_jwt, char *p_in, const char *p_sign 
     }
 
     //decode signature from input token
-    size_t sz_p_sign = strlen( p_sign );
-    size_t sz_decoded = b64url_get_decoded_buffer_size( sz_p_sign );
-    uint8_t *signed_dec = malloc( sz_decoded + 1 );
+    signed_dec = b64_url_decode( p_sign, strlen(p_sign), &sz_decoded );
 
     if( !signed_dec ) {
-        ret = ENOMEM;
-        goto err_decode;
-    }
-
-    memset( signed_dec, 0, ( sz_decoded + 1 ) );
-    //decode
-    int out_size = b64url_decode( ( uint8_t * )p_sign, sz_p_sign, signed_dec );
-
-    if( !out_size ) {
         ret = EINVAL;
         goto err_match;
     }
 
-    signed_dec[out_size] = '\0';
-    cjwt_info( "Signature length : enc %d, signature %d\n",
-               ( int )sz_signed, ( int )out_size );
+    cjwt_info( "Signature length : enc %d, signature %zd\n",
+                sz_signed, sz_decoded );
     cjwt_info( "signed token : %s\n", signed_out );
     cjwt_info( "expected token signature  %s\n", signed_dec );
 
-    if( sz_signed != out_size ) {
-        cjwt_info( "Signature length mismatch: enc %d, signature %d\n",
-                   ( int )sz_signed, ( int )out_size );
+    if( (size_t) sz_signed != sz_decoded ) {
+        cjwt_info( "Signature length mismatch: enc %d, signature %zd\n",
+                   sz_signed, sz_decoded );
         ret = EINVAL;
         goto err_match;
     }
 
-    if( 0 != CRYPTO_memcmp(signed_out, signed_dec, out_size) ) {
+    if( 0 != CRYPTO_memcmp(signed_out, signed_dec, sz_decoded) ) {
         ret = EINVAL;
     }
 
 err_match:
     free( signed_dec );
-err_decode:
     free( signed_out );
 end:
     return ret;
@@ -585,7 +555,6 @@ static int cjwt_update_header( cjwt_t *p_cjwt, char *p_dechead )
 static int cjwt_parse_payload( cjwt_t *p_cjwt, char *p_payload )
 {
     int ret, sz_payload;
-    size_t pl_desize;
     size_t out_size = 0;
     uint8_t *decoded_pl;
 
@@ -594,26 +563,17 @@ static int cjwt_parse_payload( cjwt_t *p_cjwt, char *p_payload )
     }
 
     sz_payload = strlen( ( char * )p_payload );
-    pl_desize = b64url_get_decoded_buffer_size( sz_payload );
+
+    decoded_pl = b64_url_decode( p_payload, sz_payload, &out_size );
     cjwt_info( "----------------- payload ------------------- \n" );
-    cjwt_info( "Payload Size = %d , Decoded size = %d\n", sz_payload, ( int )pl_desize );
-    decoded_pl = malloc( pl_desize + 1 );
-
-    if( !decoded_pl ) {
-        return ENOMEM;
-    }
-
-    memset( decoded_pl, 0, ( pl_desize + 1 ) );
-    //decode payload
-    out_size = b64url_decode( ( uint8_t * )p_payload, sz_payload, decoded_pl );
-    cjwt_info( "Bytes = %d\n", ( int )out_size );
+    cjwt_info( "Payload Size = %zd , Decoded size = %zd\n", sz_payload, out_size );
+    cjwt_info( "Bytes = %zd\n", out_size );
 
     if( !out_size ) {
         ret = EINVAL;
         goto end;
     }
 
-    decoded_pl[out_size] = '\0';
     cjwt_info( "Raw data  = %*s\n", ( int )out_size, decoded_pl );
     ret = cjwt_update_payload( p_cjwt, ( char* )decoded_pl );
 end:
@@ -623,8 +583,8 @@ end:
 
 static int cjwt_parse_header( cjwt_t *p_cjwt, char *p_head )
 {
-    int sz_head, ret = 0;
-    size_t head_desize;
+    size_t sz_head = 0;
+    int ret = 0;
     uint8_t *decoded_head;
     size_t out_size = 0;
 
@@ -633,26 +593,15 @@ static int cjwt_parse_header( cjwt_t *p_cjwt, char *p_head )
     }
 
     sz_head = strlen( ( char * )p_head );
-    head_desize = b64url_get_decoded_buffer_size( sz_head );
+    decoded_head = b64_url_decode( p_head, sz_head, &out_size );
     cjwt_info( "----------------- header -------------------- \n" );
-    cjwt_info( "Header Size = %d , Decoded size = %d\n", sz_head, ( int )head_desize );
-    decoded_head = malloc( head_desize + 1 );
-
-    if( !decoded_head ) {
-        return ENOMEM;
-    }
-
-    memset( decoded_head, 0, head_desize + 1 );
-    //decode header
-    out_size = b64url_decode( ( uint8_t * )p_head, sz_head, decoded_head );
-    cjwt_info( "Bytes = %d\n", ( int )out_size );
+    cjwt_info( "Header Size = %zd , Decoded size = %zd\n", sz_head, out_size );
 
     if( !out_size ) {
         ret = EINVAL;
         goto end;
     }
 
-    decoded_head[out_size] = '\0';
     cjwt_info( "Raw data  = %*s\n", ( int )out_size, decoded_head );
     ret = cjwt_update_header( p_cjwt, ( char* )decoded_head );
 end:

--- a/src/cjwt.c
+++ b/src/cjwt.c
@@ -152,7 +152,8 @@ static int cjwt_sign( cjwt_t *cjwt, unsigned char **out, const char *in, int *ou
             return cjwt_sign_sha_hmac( cjwt, out, EVP_sha384(), in, out_len );
         case alg_hs512:
             return cjwt_sign_sha_hmac( cjwt, out, EVP_sha512(), in, out_len );
-        default :
+        default:
+            break;
     }//switch
 
     return -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,13 +13,18 @@ find_package (Threads)
 
 link_directories ( ${LIBRARY_DIR} )
 
-add_test(NAME test_cjwt COMMAND ${MEMORY_CHECK} ./test_cjwt)
-add_executable(test_cjwt test_cjwt.c ../src/cjwt.c)
+add_test(NAME test_b64 COMMAND ${MEMORY_CHECK} ./test_b64)
+add_executable(test_b64 test_b64.c ../src/b64.c)
+target_link_libraries (test_b64 ${CUNIT_LIBRARIES})
 
-target_link_libraries (test_cjwt ${CUNIT_LIBRARIES})
-target_link_libraries (test_cjwt ${CJSON_LIBRARIES})
-target_link_libraries (test_cjwt ${TROWER_LIBRARIES})
-target_link_libraries (test_cjwt ${OPENSSL_LIBRARIES})
-target_link_libraries (test_cjwt -lm)
-target_link_libraries (test_cjwt gcov)
-target_link_libraries (test_cjwt rt)
+
+
+add_test(NAME test_cjwt COMMAND ${MEMORY_CHECK} ./test_cjwt)
+add_executable(test_cjwt test_cjwt.c ../src/b64.c ../src/cjwt.c)
+
+target_link_libraries (test_cjwt ${CUNIT_LIBRARIES}
+                                 ${CJSON_LIBRARIES}
+                                 ${OPENSSL_LIBRARIES}
+                                 -lm
+                                 gcov
+                                 rt)

--- a/tests/test_b64.c
+++ b/tests/test_b64.c
@@ -50,6 +50,43 @@ void test_b64_url_decode()
             .out_len = 0,
         },
 
+        /* Protect against a bogus empty string */
+        {   .in = "==",
+            .in_len = 2,
+            .out = NULL,
+            .out_len = 0,
+        },
+
+        /* Invalid, safely fail. */
+        {   .in = "b==",
+            .in_len = 3,
+            .out = NULL,
+            .out_len = 0,
+        },
+
+        /* Invalid, padding. */
+        {   .in = "ba=",
+            .in_len = 3,
+            .out = NULL,
+            .out_len = 0,
+        },
+        {   .in = "bad==",
+            .in_len = 5,
+            .out = NULL,
+            .out_len = 0,
+        },
+        {   .in = "bad4==",
+            .in_len = 6,
+            .out = NULL,
+            .out_len = 0,
+        },
+        {   .in = "bad4=",
+            .in_len = 5,
+            .out = NULL,
+            .out_len = 0,
+        },
+
+
         /* Disallow other forms. */
         {   .in = "ab+d", .in_len = 4, .out = NULL, .out_len = 0, },
         {   .in = "as/d", .in_len = 4, .out = NULL, .out_len = 0, },

--- a/tests/test_b64.c
+++ b/tests/test_b64.c
@@ -1,0 +1,243 @@
+/* SPDX-FileCopyrightText: 2021 Comcast Cable Communications Management, LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <CUnit/Basic.h>
+
+#include "../src/b64.h"
+
+
+struct test_vector {
+    const char *in;
+    size_t in_len;
+    const char *out;
+    size_t out_len;
+};
+
+void test_b64_url_decode()
+{
+    struct test_vector tests[] = {
+        /* Simple NULL, string length tests */
+        {   .in = NULL,
+            .in_len = 0,
+            .out = NULL,
+            .out_len = 0,
+        },
+        {   .in = "asdf123",
+            .in_len = 0,
+            .out = NULL,
+            .out_len = 0,
+        },
+
+        /* The length must be at least 2 */
+        {   .in = "a",
+            .in_len = 1,
+            .out = NULL,
+            .out_len = 0,
+        },
+
+        /* Every character must be valid */
+        {   .in = "asdf1\xffjj",
+            .in_len = 8,
+            .out = NULL,
+            .out_len = 0,
+        },
+        {   .in = "asdf1=jj",
+            .in_len = 8,
+            .out = NULL,
+            .out_len = 0,
+        },
+
+        /* Disallow other forms. */
+        {   .in = "ab+d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as/d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as,d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as,d", .in_len = 4, .out = NULL, .out_len = 0, },
+
+        /* Disallow other printable charcters. */
+        {   .in = "as d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as!d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\"d",.in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as#d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as$d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as%d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as&d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as'd", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as(d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as)d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as*d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as.d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as:d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as;d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as<d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as>d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as?d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as@d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as[d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\\d",.in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as]d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as^d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as`d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as{d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as|d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as}d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as~d", .in_len = 4, .out = NULL, .out_len = 0, },
+
+        /* Disallow other non-printable charcters. */
+        {   .in = "as\x00d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x01d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x02d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x03d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x04d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x05d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x06d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x07d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x08d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x09d", .in_len = 4, .out = NULL, .out_len = 0, },
+        {   .in = "as\x0ad", .in_len = 4, .out = NULL, .out_len = 0, },
+
+        /* A remainder of 1 is never valid */
+        {   .in = "TWFub",
+            .in_len = 5,
+            .out = NULL,
+            .out_len = 0,
+        },
+
+        /* Simple valid examples */
+        {   .in = "TWFu",
+            .in_len = 4,
+            .out = "Man",
+            .out_len = 3,
+        },
+        {   .in = "TWE=",
+            .in_len = 4,
+            .out = "Ma",
+            .out_len = 2,
+        },
+        {   .in = "TQ==",
+            .in_len = 4,
+            .out = "M",
+            .out_len = 1,
+        },
+
+        /* The padding '=' is optional for the URL variant. */
+        {   .in = "TWE",
+            .in_len = 3,
+            .out = "Ma",
+            .out_len = 2,
+        },
+        {   .in = "TQ",
+            .in_len = 2,
+            .out = "M",
+            .out_len = 1,
+        },
+
+        /* A longer sample text. */
+        {   .in = "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24s"
+                  "IGJ1dCBieSB0aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmlt"
+                  "YWxzLCB3aGljaCBpcyBhIGx1c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBw"
+                  "ZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGludWVkIGFuZCBp"
+                  "bmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRz"
+                  "IHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=",
+            .in_len = 360,
+            .out = "Man is distinguished, not only by his reason, but by this "
+                   "singular passion from other animals, which is a lust of "
+                   "the mind, that by a perseverance of delight in the "
+                   "continued and indefatigable generation of knowledge, "
+                   "exceeds the short vehemence of any carnal pleasure.",
+            .out_len = 269,
+        },
+
+        /* Use every character to ensure they all map properly */
+        {   .in = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                  "abcdefghijklmnopqrstuvwxyz"
+                  "0123456789-_",
+            .in_len = 64,
+            .out = "\x00\x10\x83\x10\x51\x87\x20\x92\x8b\x30"
+                   "\xd3\x8f\x41\x14\x93\x51\x55\x97\x61\x96"
+                   "\x9b\x71\xd7\x9f\x82\x18\xa3\x92\x59\xa7"
+                   "\xa2\x9a\xab\xb2\xdb\xaf\xc3\x1c\xb3\xd3"
+                   "\x5d\xb7\xe3\x9e\xbb\xf3\xdf\xbf",
+            .out_len = 48,
+        },
+
+    };
+
+    for( size_t i = 0; i < sizeof(tests)/sizeof(struct test_vector); i++ ) {
+        uint8_t *got;
+        size_t got_len = 0xffff0;
+
+        got = b64_url_decode( tests[i].in, tests[i].in_len, &got_len );
+
+        if( !tests[i].out ) {
+            CU_ASSERT_FATAL( NULL == got );
+            CU_ASSERT_FATAL( 0xffff0 == got_len );
+        } else {
+            CU_ASSERT_FATAL( NULL != got );
+
+            CU_ASSERT_FATAL( tests[i].out_len == got_len );
+            if( 0 < tests[i].out_len ) {
+                for( size_t j = 0; j < tests[i].out_len; j++ ) {
+                    CU_ASSERT( (uint8_t) tests[i].out[j] == got[j] );
+                }
+
+                free( got );
+            }
+        }
+
+        /* Run the test again with no length */
+        got = b64_url_decode( tests[i].in, tests[i].in_len, NULL );
+        if( !tests[i].out ) {
+            CU_ASSERT_FATAL( NULL == got );
+        } else {
+            CU_ASSERT_FATAL( NULL != got );
+
+            if( 0 < tests[i].out_len ) {
+                for( size_t j = 0; j < tests[i].out_len; j++ ) {
+                    CU_ASSERT( (uint8_t) tests[i].out[j] == got[j] );
+                }
+
+                free( got );
+            }
+        }
+    }
+}
+
+
+void add_suites( CU_pSuite *suite )
+{
+    *suite = CU_add_suite( "b64_url_decode tests", NULL, NULL );
+    CU_add_test( *suite, "General Tests", test_b64_url_decode );
+}
+
+
+/*----------------------------------------------------------------------------*/
+/*                             External Functions                             */
+/*----------------------------------------------------------------------------*/
+int main( void )
+{
+    unsigned rv = 1;
+    CU_pSuite suite = NULL;
+
+    if( CUE_SUCCESS == CU_initialize_registry() ) {
+        add_suites( &suite );
+
+        if( NULL != suite ) {
+            CU_basic_set_mode( CU_BRM_VERBOSE );
+            CU_basic_run_tests();
+            printf( "\n" );
+            CU_basic_show_failures( CU_get_failure_list() );
+            printf( "\n\n" );
+            rv = CU_get_number_of_tests_failed();
+        }
+
+        CU_cleanup_registry();
+    }
+
+    if( 0 != rv ) {
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
After running some tests against the exiting trower-base64
implementation useage, there were ways to pass in invalid data that was
not being caught.  Adding the base64 url decoder here removes a
dependency at no cost of quality.